### PR TITLE
scssPath & sassPath opts now could be arrays

### DIFF
--- a/src/sass.plugin.coffee
+++ b/src/sass.plugin.coffee
@@ -89,7 +89,7 @@ module.exports = (BasePlugin) ->
 				return next(new Error(locale[inExtension+'NotInstalled']))  unless execPath
 
 				# Build our command
-				command = [execPath, '--stdin', '--no-cache']
+				command = [].concat(execPath,['--stdin', '--no-cache'])
 				if fullDirPath
 					command.push('--load-path')
 					command.push(fullDirPath)


### PR DESCRIPTION
If you want to use bundler you can set something like this in docpad.coffee:
    plugins:
        sass:
            scssPath: ['bundle','exec','scss']
            sassPath: ['bundle','exec','sass']
