### PR TITLE
array push assigned to command if sourcemaps true

### DIFF
--- a/src/sass.plugin.coffee
+++ b/src/sass.plugin.coffee
@@ -96,7 +96,7 @@ module.exports = (BasePlugin) ->
 
 				# Sourcemaps or stdin?
 				if config.sourcemap
-					command = command.push("#{file.attributes.fullPath}:#{file.attributes.outPath}", '--no-cache', '--update', '--sourcemap')
+					command.push("#{file.attributes.fullPath}:#{file.attributes.outPath}", '--no-cache', '--update', '--sourcemap')
 				else
 					command.push('--no-cache', '--stdin')
 					commandOpts.stdin = opts.content


### PR DESCRIPTION
when sourcemaps is enabled command.push() output is assigned to command overwriting command array which make command unusable
