### PR TITLE
Support multi loadPath

### DIFF
--- a/src/sass.plugin.coffee
+++ b/src/sass.plugin.coffee
@@ -107,6 +107,11 @@ module.exports = (BasePlugin) ->
 				if fullDirPath
 					command.push('--load-path')
 					command.push(fullDirPath)
+				
+				if config.loadPaths
+					config.loadPaths.forEach (loadPath) ->
+						command.push('--load-path')
+						command.push(loadPath)
 
 				if config.compass
 					command.push('--compass')


### PR DESCRIPTION
In some cases, we need transfer external load path for plugin, you can do it in docpad.coffee
plugins:
    sass:
      loadPaths: ["other", "path"]
